### PR TITLE
log out response data, return only accountMemberId from lambda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: scala
+
+scala:
+  - 2.12.6
+
+env:
+  - JDK=oraclejdk8
+
+before_script:
+  - jdk_switcher use $JDK
+
+script: sbt ++$TRAVIS_SCALA_VERSION clean stack/clean 'test-only -- timefactor 10' 'stack/test-only -- timefactor 10'

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,8 @@
+The MIT License (MIT)
+Copyright © 2016 Dwolla
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/main/scala/com/dwolla/lambda/cloudflare/requests/processors/AccountMembership.scala
+++ b/src/main/scala/com/dwolla/lambda/cloudflare/requests/processors/AccountMembership.scala
@@ -8,6 +8,7 @@ import com.dwolla.lambda.cloudflare.Exceptions.{MissingRoles, UnsupportedAction}
 import com.dwolla.lambda.cloudflare.util.JValue._
 import com.dwolla.lambda.cloudformation.HandlerResponse
 import org.json4s.{DefaultFormats, Formats, JValue}
+import org.json4s.native.Serialization
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -78,7 +79,7 @@ class AccountMembership(implicit ec: ExecutionContext) extends ResourceRequestPr
     physicalResourceId match {
       case accountMemberUriRegex(accountId, accountMemberId) ⇒
         accountsClient.removeAccountMember(accountId, accountMemberId) map { deleted ⇒
-          HandlerResponse(physicalResourceId, Map("deletedAccountMemberId" → deleted))
+          HandlerResponse(physicalResourceId, Map("accountMemberId" → deleted))
         }
       case _ ⇒
         logger.error(s"The physical resource id $physicalResourceId does not match the URL pattern for a Cloudflare account")
@@ -116,7 +117,9 @@ class AccountMembership(implicit ec: ExecutionContext) extends ResourceRequestPr
       "oldAccountMember" → existing
     )
 
-    HandlerResponse(accountMember.uri(accountId), data)
+    logger.info(s"Cloudflare AccountMembership response data: ${Serialization.write(data)}")
+
+    HandlerResponse(accountMember.uri(accountId), Map("accountMemberId" → accountMember.id))
   }
 }
 


### PR DESCRIPTION
Custom Cloudformation resources can only return 4K of data, so changed the lambda to return only the affected accountMemberid, and to log the rest of the data we might be interested in.