### PR TITLE
use an older version of the sbt-s3-plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 logLevel := Level.Warn
-addSbtPlugin("com.dwolla.sbt" %% "sbt-s3-publisher" % "1.1.1")
+addSbtPlugin("com.dwolla.sbt" %% "sbt-s3-publisher" % "1.0.2")
 addSbtPlugin("com.dwolla.sbt" %% "sbt-cloudformation-stack" % "1.2.1")
 
 resolvers ++= Seq(


### PR DESCRIPTION
There seems to be a bug introduced in version 1.1.0 of the sbt-s3-plugin. Reverting to an older version to unblock and investigate.