### PR TITLE
Added extra iam permissions to work with existing log group

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -22,6 +22,17 @@ provider:
           Action:
            - route53:GetHostedZone
           Resource: '*'
+        - Effect: Allow
+          Action:
+           - logs:CreateLogStream
+           - logs:CreateLogGroup
+          Resource:
+           - "arn:aws:iam::${env:ACCOUNT}:log-group:/aws/lambda/cloudflare-lambda-Function-*:*"
+        - Effect: Allow
+          Action:
+           - logs:PutLogEvents
+          Resource:
+           - "arn:aws:iam::${env:ACCOUNT}:log-group:/aws/lambda/cloudflare-lambda-Function-*:*:*"
   logRetentionInDays: 7
   stackTags:
     Creator: serverless


### PR DESCRIPTION
We currently have a log group that already exists with a function that already exists. This adds permissions to those already existing log groups. This will not impact new deployments.